### PR TITLE
fix(supermemory): gate indexing readiness on dreamingStatus

### DIFF
--- a/src/providers/supermemory/index.ts
+++ b/src/providers/supermemory/index.ts
@@ -83,11 +83,14 @@ export class SupermemoryProvider implements Provider {
       const results = await Promise.allSettled(
         pendingArray.map(async (docId) => {
           const doc = await this.client!.documents.get(docId)
-          if (doc.status === "done" || doc.status === "failed") {
+          const dreamingStatus = (doc as { dreamingStatus?: string }).dreamingStatus
+          const docReady = doc.status === "done" && dreamingStatus !== "dreaming"
+          const docFailed = doc.status === "failed"
+          if (docReady || docFailed) {
             const memory = await this.client!.memories.get(docId)
-            return { docId, docStatus: doc.status, memStatus: memory.status }
+            return { docId, docStatus: docFailed ? "failed" : "done", memStatus: memory.status }
           }
-          return { docId, docStatus: doc.status, memStatus: "pending" }
+          return { docId, docStatus: "pending", memStatus: "pending" }
         })
       )
 


### PR DESCRIPTION
## What

The Supermemory indexing poll (`awaitIndexing`) previously treated `doc.status === "done"` as fully indexed. That's unsafe with the deferred dreaming path: the backend atomically writes `status:"done"` + `dreamingStatus:"dreaming"`, so a doc reads `"done"` the **entire time** dreaming inference runs. Searching during that window returns nothing.

## Change

A doc is now considered ready only when:

```ts
doc.status === "done" && dreamingStatus !== "dreaming"
```

(still also gated on `memory.status === "done"` downstream).

Why not `dreamingStatus` alone? Its column default is `"done"`, so a doc still at `status:"indexing"` would read `dreamingStatus:"done"` and be declared ready before ingest even finishes. Both fields together is the only race-free condition.

`dreamingStatus` is read via a cast since the installed `supermemory` SDK type (`DocumentGetResponse`) doesn't expose the field yet.

## Testing

Not yet validated end-to-end — the local worker on :8787 was flapping (503 / 500 / connection refused) during attempts, so ingest never reached the indexing phase. Logic type-checks clean. Worth a run against a stable backend before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)