### PR TITLE
fix(supermemory): honor options.limit in search() instead of hardcoding 30

### DIFF
--- a/src/providers/supermemory/index.ts
+++ b/src/providers/supermemory/index.ts
@@ -123,7 +123,7 @@ export class SupermemoryProvider implements Provider {
     const response = await this.client.search.memories({
       q: query,
       containerTag: options.containerTag,
-      limit: 30,
+      limit: options.limit ?? 30,
       threshold: options.threshold || 0.3,
 			searchMode: "hybrid",
 			include: {


### PR DESCRIPTION
### Problem
`SupermemoryProvider.search()` hardcodes `limit: 30`, silently overriding whatever `limit` the caller passes in `SearchOptions` — a consumer requesting a deeper retrieval pool still caps at 30.

### Fix
Honor `options.limit`, keeping `30` as the default:

```ts
limit: options.limit ?? 30,
```

`SearchOptions.limit` already exists in `src/types/provider.ts`, so no type changes, and callers that don't pass `limit` see identical behavior. Typechecks clean.

Flagged by @sohamd22 in #44 review. #57 is stacked on this branch.