### PR TITLE
fix(server): reject path traversal in run/comparison IDs and drop wildcard CORS

### DIFF
--- a/src/orchestrator/batch.ts
+++ b/src/orchestrator/batch.ts
@@ -5,6 +5,7 @@ import type { BenchmarkResult } from "../types/unified"
 import { orchestrator, CheckpointManager } from "./index"
 import { createBenchmark } from "../benchmarks"
 import { logger } from "../utils/logger"
+import { assertSafeId } from "../utils/paths"
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { startRun, endRun } from "../server/runState"
@@ -84,7 +85,7 @@ function selectQuestionsBySampling(
 
 export class BatchManager {
   private getComparePath(compareId: string): string {
-    return join(COMPARE_DIR, compareId)
+    return join(COMPARE_DIR, assertSafeId(compareId, "comparison ID"))
   }
 
   private getManifestPath(compareId: string): string {
@@ -122,7 +123,7 @@ export class BatchManager {
     const manifest = this.loadManifest(compareId)
     if (manifest) {
       for (const run of manifest.runs) {
-        const runPath = join(RUNS_DIR, run.runId)
+        const runPath = join(RUNS_DIR, assertSafeId(run.runId, "run ID"))
         if (existsSync(runPath)) {
           rmSync(runPath, { recursive: true })
         }
@@ -131,7 +132,7 @@ export class BatchManager {
   }
 
   loadReport(runId: string): BenchmarkResult | null {
-    const reportPath = join(RUNS_DIR, runId, "report.json")
+    const reportPath = join(RUNS_DIR, assertSafeId(runId, "run ID"), "report.json")
     if (!existsSync(reportPath)) return null
     try {
       return JSON.parse(readFileSync(reportPath, "utf8")) as BenchmarkResult

--- a/src/orchestrator/checkpoint.ts
+++ b/src/orchestrator/checkpoint.ts
@@ -21,6 +21,7 @@ import type {
 import type { ConcurrencyConfig } from "../types/concurrency"
 import { PHASE_ORDER } from "../types/checkpoint"
 import { logger } from "../utils/logger"
+import { assertSafeId } from "../utils/paths"
 
 const RUNS_DIR = "./data/runs"
 
@@ -32,8 +33,11 @@ export class CheckpointManager {
     this.basePath = basePath
   }
 
+  // Every path this class builds routes through here, so validating the run ID once
+  // covers load/exists/create/delete/copyCheckpoint and the API routes that join
+  // onto getRunPath()/getResultsDir() themselves.
   getRunPath(runId: string): string {
-    return join(this.basePath, runId)
+    return join(this.basePath, assertSafeId(runId, "run ID"))
   }
 
   getCheckpointPath(runId: string): string {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import { handleLeaderboardRoutes } from "./routes/leaderboard"
 import { handleCompareRoutes } from "./routes/compare"
 import { WebSocketManager } from "./websocket"
 import { logger } from "../utils/logger"
+import { UnsafeIdError } from "../utils/paths"
 import { join } from "path"
 import { Subprocess } from "bun"
 
@@ -14,10 +15,27 @@ export interface ServerOptions {
 
 let uiProcess: Subprocess | null = null
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+// This API deletes runs and spends provider/judge credits, and it has no auth, so a
+// wildcard Access-Control-Allow-Origin would let any website the user happens to visit
+// drive it. The UI is served from a loopback port that Next.js picks at startup, so
+// allow any loopback origin and nothing else.
+const LOOPBACK_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/
+
+function isAllowedOrigin(origin: string | null): boolean {
+  return !!origin && LOOPBACK_ORIGIN.test(origin)
+}
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    // The response now depends on the request origin, so it must not be cached across origins.
+    Vary: "Origin",
+  }
+  if (isAllowedOrigin(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin!
+  }
+  return headers
 }
 
 export const wsManager = new WebSocketManager()
@@ -30,10 +48,23 @@ export async function startServer(options: ServerOptions): Promise<void> {
 
     async fetch(req, server) {
       const url = new URL(req.url)
+      const origin = req.headers.get("origin")
+      const CORS_HEADERS = corsHeaders(origin)
 
       // Handle CORS preflight
       if (req.method === "OPTIONS") {
         return new Response(null, { headers: CORS_HEADERS })
+      }
+
+      // Belt and braces: a disallowed origin gets no ACAO above, so the browser already
+      // blocks the response. Refusing the state-changing methods outright means the
+      // side effect never happens either. Non-browser clients (CLI, curl) send no
+      // Origin at all and are unaffected.
+      if (origin && !isAllowedOrigin(origin) && req.method !== "GET") {
+        return new Response(JSON.stringify({ error: "Cross-origin request rejected" }), {
+          status: 403,
+          headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+        })
       }
 
       // WebSocket upgrade
@@ -82,8 +113,10 @@ export async function startServer(options: ServerOptions): Promise<void> {
         })
       } catch (error) {
         const message = error instanceof Error ? error.message : "Internal server error"
+        // A rejected run/comparison ID is bad input, not a server fault.
+        const status = error instanceof UnsafeIdError ? 400 : 500
         return new Response(JSON.stringify({ error: message }), {
-          status: 500,
+          status,
           headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
         })
       }

--- a/src/server/routes/leaderboard.ts
+++ b/src/server/routes/leaderboard.ts
@@ -4,7 +4,9 @@ import { join } from "path"
 import { db, schema } from "../db"
 import { CheckpointManager } from "../../orchestrator/checkpoint"
 import { createBenchmark } from "../../benchmarks"
+import { getAvailableProviders } from "../../providers"
 import type { BenchmarkName } from "../../types/benchmark"
+import type { ProviderName } from "../../types/provider"
 
 const checkpointManager = new CheckpointManager()
 
@@ -309,8 +311,17 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
   return null
 }
 
+// checkpoint.provider is whatever POST /api/runs/start supplied: the checkpoint is written
+// before createProvider() ever validates the name, so a bogus value survives on disk and
+// reaches these joins. Only ever resolve names the provider registry actually knows.
+function resolveProviderDir(provider: string): string | null {
+  if (!getAvailableProviders().includes(provider as ProviderName)) return null
+  return join(process.cwd(), "src", "providers", provider)
+}
+
 function getProviderCode(provider: string): string {
-  const providerDir = join(process.cwd(), "src", "providers", provider)
+  const providerDir = resolveProviderDir(provider)
+  if (!providerDir) return `// Unknown provider: ${provider}`
   const indexPath = join(providerDir, "index.ts")
   const promptPath = join(providerDir, "prompt.ts")
   const promptsPath = join(providerDir, "prompts.ts")
@@ -341,7 +352,8 @@ function getProviderCode(provider: string): string {
 }
 
 function getProviderPrompts(provider: string): Record<string, string> | null {
-  const providerDir = join(process.cwd(), "src", "providers", provider)
+  const providerDir = resolveProviderDir(provider)
+  if (!providerDir) return null
   const prompts: Record<string, string> = {}
 
   // Check for dedicated prompt files

--- a/src/utils/paths.test.ts
+++ b/src/utils/paths.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "bun:test"
+import { join } from "path"
+import { isSafeId, assertSafeId, UnsafeIdError } from "./paths"
+
+// The attack: /api/runs/([^/]+) matches a segment containing %2F, because URL keeps it
+// encoded in the pathname. decodeURIComponent then turns it into real separators.
+const TRAVERSALS = [
+  "../../secrets",
+  "..%2F..%2Fsecrets", // pre-decode form, in case a caller forgets to decode
+  "..",
+  ".",
+  "../",
+  "a/../../b",
+  "..\\..\\windows", // backslashes are separators on win32
+  "/etc/passwd",
+  "C:\\Windows",
+  "run-1/../..",
+  "",
+]
+
+const VALID = [
+  "run-20260101-120000",
+  "supermemory-locomo-20260101-ab12",
+  "compare-20260101-120000",
+  "compare-20260101-120000-mem0",
+  "run_1.2",
+]
+
+test("rejects every traversal vector", () => {
+  for (const id of TRAVERSALS) {
+    expect(isSafeId(id)).toBe(false)
+    expect(() => assertSafeId(id, "run ID")).toThrow(UnsafeIdError)
+  }
+})
+
+test("accepts the IDs the CLI, UI and batch runner generate", () => {
+  for (const id of VALID) {
+    expect(isSafeId(id)).toBe(true)
+    expect(assertSafeId(id)).toBe(id)
+  }
+})
+
+test("no accepted ID can escape its base directory", () => {
+  // The property that actually matters, asserted on the joined path rather than the regex.
+  for (const id of VALID) {
+    expect(join("./data/runs", id).replace(/\\/g, "/")).toBe(`data/runs/${id}`)
+  }
+})

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,31 @@
+/**
+ * Run and comparison IDs are interpolated straight into filesystem paths and then
+ * handed to rmSync/readFileSync, so they must never be able to escape their base
+ * directory. Route patterns like /api/runs/([^/]+) do not protect us: the URL
+ * pathname keeps %2F encoded, so the segment matches and only becomes a separator
+ * later, in decodeURIComponent.
+ *
+ * Every generated ID (run-20260101-120000, provider-benchmark-20260101-ab12,
+ * compare-20260101-120000, <compareId>-<provider>) fits this charset.
+ */
+// Leading character must be alphanumeric: that rules out the dot-only IDs ("." resolves
+// to the base directory itself, so rmSync would take every run with it) and IDs starting
+// with "-", which read as flags if an ID ever reaches a shell.
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+export function isSafeId(id: string): boolean {
+  // "." is in the charset, so ".." would otherwise pass and still climb.
+  return SAFE_ID.test(id) && !id.includes("..")
+}
+
+/** Lets the API layer answer 400 instead of 500 without re-validating per route. */
+export class UnsafeIdError extends Error {}
+
+export function assertSafeId(id: string, kind = "id"): string {
+  if (!isSafeId(id)) {
+    throw new UnsafeIdError(
+      `Invalid ${kind}: ${JSON.stringify(id)}. Only letters, digits, ".", "_" and "-" are allowed.`
+    )
+  }
+  return id
+}


### PR DESCRIPTION
Fixes #60  — arbitrary directory deletion via `DELETE /api/runs/:runId`, reachable from any website.

## The bug

Route patterns like `/api/runs/([^/]+)` match *before* `decodeURIComponent` runs. A URL
pathname keeps `%2F` encoded, so the segment matches, and only afterwards becomes a real
separator:

    DELETE /api/runs/..%2F..%2Fvictim
      -> regex captures "..%2F..%2Fvictim"
      -> decodeURIComponent -> "../../victim"
      -> join("./data/runs", "../../victim") -> "victim"
      -> rmSync("victim", { recursive: true })

`Access-Control-Allow-Origin: *` plus no auth and an unconditional `OPTIONS` handler made
this drivable cross-origin: any page a user visited while `serve` was running could delete
directories on their machine, or start runs that spend provider/judge credits.

## The fix

**1. Validate IDs at the chokepoint, not per route.** `CheckpointManager.getRunPath()` and
`BatchManager.getComparePath()` are the funnels every path in those classes flows through, so
one guard in each covers `load`/`exists`/`create`/`delete`/`copyCheckpoint` *and* the routes
that `join()` onto `getRunPath()`/`getResultsDir()` themselves — including the arbitrary
`report.json` read in `GET /api/runs/:runId/report` and `GET /api/leaderboard`. Rejected IDs
throw `UnsafeIdError`, which the server maps to 400 rather than 500.

The accepted charset is `/^[A-Za-z0-9][A-Za-z0-9._-]*$/` with `..` rejected outright. Every
generated ID fits it (`run-20260101-120000`, `provider-benchmark-20260101-ab12`,
`compare-20260101-120000`, `<compareId>-<provider>`).

The leading-alphanumeric requirement matters more than it looks: `"."` passes a plain
`[A-Za-z0-9._-]+` charset and contains no `..`, but `join("./data/runs", ".")` resolves to the
base directory itself — `rmSync` would have taken *every* run with it. The test caught this.

**2. Replace the wildcard CORS with a loopback allowlist.** The UI's port is chosen by Next.js
at startup, so any loopback origin is reflected and nothing else is. State-changing methods
from a disallowed origin are refused with 403, so the side effect never happens even if a
client ignores the missing `ACAO`. Requests with no `Origin` at all (CLI, curl) are unaffected.
Added `Vary: Origin` since the response now depends on it.

**3. Same class of bug next door:** `getProviderCode`/`getProviderPrompts` joined
`checkpoint.provider` into a path. The checkpoint is written *before* `createProvider()`
validates the name, so a bogus provider survives on disk and reaches the join. Now resolved
against the existing `getAvailableProviders()` registry.

## Verification

- `src/utils/paths.test.ts` — 11 traversal vectors rejected (`../../secrets`, the pre-decode
  `..%2F..%2F` form, `..`, `.`, backslash separators, absolute paths), the generated ID formats
  accepted, and the joined-path containment property asserted directly rather than via the regex.
- Ran the decoded attack against a real `CheckpointManager` over a sandbox tree: `delete` and
  `load` both reject, the victim files survive, `data/runs` itself survives, and a legitimate
  run still round-trips create -> load -> delete.
- Origin allowlist checked against spoofing attempts (`localhost.evil.com`,
  `127.0.0.1.evil.com`, `localhost:3000.evil.com`, `null`) plus the real UI origins.
- `bun test` green; `prettier --check` clean on all touched files.

## Notes for the reviewer

- `checkpoint.ts` was already unformatted at HEAD, so I left the rest of that file alone rather
  than bury a security fix under a whole-file reformat. My added lines are prettier-clean.
- Unrelated bug noticed while reading `BatchManager.delete` and deliberately **not** fixed here:
  it `rmSync`s the comparison directory and only *then* calls `loadManifest`, which reads
  `manifest.json` from inside the directory it just removed. The manifest is therefore always
  `null` and member runs are never actually deleted. Worth its own issue.