### PR TITLE
fix(models): pass maxOutputTokens so output caps actually apply on AI SDK v5

### DIFF
--- a/src/judges/README.md
+++ b/src/judges/README.md
@@ -43,10 +43,14 @@ interface ModelConfig {
     displayName: string
     supportsTemperature: boolean
     defaultTemperature: number
-    maxTokensParam: "maxTokens" | "max_completion_tokens"
     defaultMaxTokens: number
 }
 ```
+
+`defaultMaxTokens` is passed to the AI SDK as `maxOutputTokens`, which the SDK maps to each
+provider's own parameter — there is no per-provider parameter name to configure. Give
+reasoning/thinking models a roomy value: their reasoning tokens are billed against the same
+ceiling, so a tight cap can be spent before any visible answer is produced.
 
 ## Provider-Specific Prompts
 

--- a/src/judges/anthropic.ts
+++ b/src/judges/anthropic.ts
@@ -27,17 +27,14 @@ export class AnthropicJudge implements Judge {
 
     const prompt = buildJudgePrompt(input)
 
-    const params: Record<string, unknown> = {
+    const { text } = await generateText({
       model: this.client(this.modelConfig.id),
       prompt,
-      maxTokens: this.modelConfig.defaultMaxTokens,
-    }
-
-    if (this.modelConfig.supportsTemperature) {
-      params.temperature = this.modelConfig.defaultTemperature
-    }
-
-    const { text } = await generateText(params as Parameters<typeof generateText>[0])
+      maxOutputTokens: this.modelConfig.defaultMaxTokens,
+      ...(this.modelConfig.supportsTemperature
+        ? { temperature: this.modelConfig.defaultTemperature }
+        : {}),
+    })
 
     return parseJudgeResponse(text)
   }

--- a/src/judges/base.ts
+++ b/src/judges/base.ts
@@ -28,6 +28,16 @@ System's Hypothesis: ${input.hypothesis}`
 }
 
 export function parseJudgeResponse(response: string): JudgeResult {
+  // An empty completion is not a verdict. Now that maxOutputTokens is actually enforced,
+  // a reasoning model can spend its whole ceiling on reasoning and return nothing; scoring
+  // that as "incorrect" would silently mark questions wrong and skew the run's accuracy.
+  // Throwing lets the evaluate phase record a real failure that a resume can retry.
+  if (!response.trim()) {
+    throw new Error(
+      "Judge returned an empty response (likely truncated before producing a verdict — check the model's maxOutputTokens)"
+    )
+  }
+
   try {
     const jsonMatch = response.match(/\{[\s\S]*\}/)
     if (!jsonMatch) {

--- a/src/judges/google.ts
+++ b/src/judges/google.ts
@@ -27,17 +27,14 @@ export class GoogleJudge implements Judge {
 
     const prompt = buildJudgePrompt(input)
 
-    const params: Record<string, unknown> = {
+    const { text } = await generateText({
       model: this.client(this.modelConfig.id),
       prompt,
-      maxTokens: this.modelConfig.defaultMaxTokens,
-    }
-
-    if (this.modelConfig.supportsTemperature) {
-      params.temperature = this.modelConfig.defaultTemperature
-    }
-
-    const { text } = await generateText(params as Parameters<typeof generateText>[0])
+      maxOutputTokens: this.modelConfig.defaultMaxTokens,
+      ...(this.modelConfig.supportsTemperature
+        ? { temperature: this.modelConfig.defaultTemperature }
+        : {}),
+    })
 
     return parseJudgeResponse(text)
   }

--- a/src/judges/openai.ts
+++ b/src/judges/openai.ts
@@ -27,18 +27,16 @@ export class OpenAIJudge implements Judge {
 
     const prompt = buildJudgePrompt(input)
 
-    const params: Record<string, unknown> = {
+    // No `as Parameters<typeof generateText>[0]` cast here: it suppressed excess-property
+    // checking, which is why the v4 `maxTokens` name survived the AI SDK v5 upgrade unnoticed.
+    const { text } = await generateText({
       model: this.client(this.modelConfig.id),
       prompt,
-    }
-
-    if (this.modelConfig.supportsTemperature) {
-      params.temperature = this.modelConfig.defaultTemperature
-    }
-
-    params.maxTokens = this.modelConfig.defaultMaxTokens
-
-    const { text } = await generateText(params as Parameters<typeof generateText>[0])
+      maxOutputTokens: this.modelConfig.defaultMaxTokens,
+      ...(this.modelConfig.supportsTemperature
+        ? { temperature: this.modelConfig.defaultTemperature }
+        : {}),
+    })
 
     return parseJudgeResponse(text)
   }

--- a/src/orchestrator/phases/answer.ts
+++ b/src/orchestrator/phases/answer.ts
@@ -129,17 +129,14 @@ export async function runAnswerPhase(
         // custom prompt functions that transform context (e.g. Zep's XML-like tags).
         const contextTokens = Math.max(0, promptTokens - basePromptTokens)
 
-        const params: Record<string, unknown> = {
+        const { text } = await generateText({
           model: client(modelConfig.id),
           prompt,
-          maxTokens: modelConfig.defaultMaxTokens,
-        }
-
-        if (modelConfig.supportsTemperature) {
-          params.temperature = modelConfig.defaultTemperature
-        }
-
-        const { text } = await generateText(params as Parameters<typeof generateText>[0])
+          maxOutputTokens: modelConfig.defaultMaxTokens,
+          ...(modelConfig.supportsTemperature
+            ? { temperature: modelConfig.defaultTemperature }
+            : {}),
+        })
 
         const durationMs = Date.now() - startTime
         checkpointManager.updatePhase(checkpoint, question.questionId, "answer", {

--- a/src/prompts/extraction.ts
+++ b/src/prompts/extraction.ts
@@ -1,9 +1,17 @@
 import { createOpenAI } from "@ai-sdk/openai"
 import { generateText } from "ai"
 import type { UnifiedSession } from "../types/unified"
+import { logger } from "../utils/logger"
 
 /** Model used for memory extraction (fast, cheap, sufficient for extraction) */
 const EXTRACTION_MODEL = "gpt-4o-mini"
+/**
+ * A long session can yield dozens of bullets, and this ceiling is now actually enforced
+ * (it previously used the AI SDK v4 `maxTokens` name and was silently dropped), so it needs
+ * real headroom: a truncated extraction quietly drops memories from the corpus the
+ * filesystem/rag providers are scored on.
+ */
+const EXTRACTION_MAX_TOKENS = 8000
 
 /**
  * Build an extraction prompt that instructs the LLM to extract structured
@@ -74,14 +82,20 @@ export async function extractMemories(
 ): Promise<string> {
   const prompt = buildExtractionPrompt(session)
 
-  const params: Record<string, unknown> = {
+  const { text, finishReason } = await generateText({
     model: openai(EXTRACTION_MODEL),
     prompt,
-    maxTokens: 2000,
+    maxOutputTokens: EXTRACTION_MAX_TOKENS,
     temperature: 0,
-  }
+  })
 
-  const { text } = await generateText(params as Parameters<typeof generateText>[0])
+  // Truncation here silently shrinks the memory corpus, which reads as a provider
+  // quality problem rather than a harness limit. Say so instead.
+  if (finishReason === "length") {
+    logger.warn(
+      `Memory extraction for session ${session.sessionId} hit the ${EXTRACTION_MAX_TOKENS}-token ceiling and was truncated; some memories are missing.`
+    )
+  }
 
   return text.trim()
 }

--- a/src/utils/models.test.ts
+++ b/src/utils/models.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { MODEL_CONFIGS, getModelConfig } from "./models"
+
+// Reasoning/thinking models are billed for reasoning tokens against the same ceiling as
+// visible output, so a tight maxOutputTokens can be consumed before any answer is emitted.
+// An empty judge completion would mark questions incorrect, so these need real headroom.
+const NEEDS_HEADROOM = /^(gpt-5|o1|o3|o4|gemini-2\.5|gemini-3)/
+const HEADROOM_FLOOR = 25000
+
+test("every model config declares a positive output ceiling", () => {
+  for (const [alias, config] of Object.entries(MODEL_CONFIGS)) {
+    expect(config.defaultMaxTokens, alias).toBeGreaterThan(0)
+  }
+})
+
+test("reasoning and thinking models get enough headroom to emit a verdict", () => {
+  for (const [alias, config] of Object.entries(MODEL_CONFIGS)) {
+    if (NEEDS_HEADROOM.test(alias) || !config.supportsTemperature) {
+      expect(config.defaultMaxTokens, alias).toBeGreaterThanOrEqual(HEADROOM_FLOOR)
+    }
+  }
+})
+
+test("unknown models fall back to a ceiling that cannot truncate a verdict", () => {
+  // We cannot tell whether an unrecognised model reasons, so the fallback must be roomy.
+  for (const alias of ["gpt-5.5", "o5-mini", "gpt-4.7", "claude-opus-5", "gemini-4-pro"]) {
+    expect(getModelConfig(alias).defaultMaxTokens, alias).toBeGreaterThanOrEqual(HEADROOM_FLOOR)
+  }
+})
+
+test("non-reasoning models stay capped tightly enough to be worth capping", () => {
+  for (const alias of ["gpt-4o", "gpt-4.1-mini", "sonnet-4", "opus-4.5"]) {
+    expect(getModelConfig(alias).defaultMaxTokens, alias).toBeLessThanOrEqual(4000)
+  }
+})

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -4,9 +4,24 @@ export interface ModelConfig {
   displayName: string
   supportsTemperature: boolean
   defaultTemperature: number
-  maxTokensParam: "maxTokens" | "max_completion_tokens" | "maxOutputTokens"
+  /**
+   * Ceiling passed as the AI SDK's `maxOutputTokens`. This is a runaway guard, not a
+   * budget: judge verdicts and benchmark answers are short, so a normal call uses a
+   * fraction of it.
+   *
+   * Reasoning/thinking models need far more headroom than the visible answer suggests.
+   * The SDK forwards this as `max_completion_tokens` for OpenAI reasoning models, which
+   * counts reasoning tokens *and* visible output, so a tight cap can be spent entirely
+   * on internal reasoning and return empty text. An empty judge response would score
+   * every question "incorrect", so these get ROOMY_MAX_TOKENS.
+   */
   defaultMaxTokens: number
 }
+
+/** Enough for a short answer or verdict on a non-reasoning model. */
+const SHORT_MAX_TOKENS = 1000
+/** Leaves room for reasoning/thinking tokens that are billed against the same ceiling. */
+const ROOMY_MAX_TOKENS = 25000
 
 export const MODEL_CONFIGS: Record<string, ModelConfig> = {
   // OpenAI - Standard models (support temperature)
@@ -16,8 +31,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-4o (Legacy)",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "gpt-4o-mini": {
     id: "gpt-4o-mini",
@@ -25,8 +39,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-4o Mini (Legacy)",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "gpt-4.1": {
     id: "gpt-4.1",
@@ -34,8 +47,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-4.1",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "gpt-4.1-mini": {
     id: "gpt-4.1-mini",
@@ -43,8 +55,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-4.1 Mini",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "gpt-4.1-nano": {
     id: "gpt-4.1-nano",
@@ -52,8 +63,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-4.1 Nano",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
 
   // OpenAI - Reasoning models (NO temperature support)
@@ -63,8 +73,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-5",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "gpt-5-mini": {
     id: "gpt-5-mini",
@@ -72,8 +81,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "GPT-5 Mini",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   o1: {
     id: "o1",
@@ -81,8 +89,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o1",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "o1-pro": {
     id: "o1-pro",
@@ -90,8 +97,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o1 Pro",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   o3: {
     id: "o3",
@@ -99,8 +105,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o3",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "o3-mini": {
     id: "o3-mini",
@@ -108,8 +113,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o3 Mini",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "o3-pro": {
     id: "o3-pro",
@@ -117,8 +121,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o3 Pro",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "o4-mini": {
     id: "o4-mini",
@@ -126,8 +129,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "o4 Mini",
     supportsTemperature: false,
     defaultTemperature: 1,
-    maxTokensParam: "max_completion_tokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
 
   // Anthropic - All Claude models (support temperature)
@@ -137,8 +139,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Claude Opus 4.5",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "sonnet-4.5": {
     id: "claude-sonnet-4-5-20250929",
@@ -146,8 +147,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Claude Sonnet 4.5",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "haiku-4.5": {
     id: "claude-haiku-4-5-20251001",
@@ -155,8 +155,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Claude Haiku 4.5",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "opus-4.1": {
     id: "claude-opus-4-1-20250805",
@@ -164,8 +163,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Claude Opus 4.1",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
   "sonnet-4": {
     id: "claude-sonnet-4-20250514",
@@ -173,8 +171,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Claude Sonnet 4",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
 
   // Google - Gemini 2.x (support temperature)
@@ -184,8 +181,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Gemini 2.5 Pro",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "gemini-2.5-flash": {
     id: "gemini-2.5-flash",
@@ -193,8 +189,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Gemini 2.5 Flash",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "gemini-2.5-flash-lite": {
     id: "gemini-2.5-flash-lite",
@@ -202,8 +197,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Gemini 2.5 Flash Lite",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
   "gemini-2.0-flash": {
     id: "gemini-2.0-flash",
@@ -211,8 +205,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Gemini 2.0 Flash",
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: SHORT_MAX_TOKENS,
   },
 
   // Google - Gemini 3 (MUST use temperature=1, lower causes issues)
@@ -222,8 +215,7 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
     displayName: "Gemini 3 Pro Preview",
     supportsTemperature: true,
     defaultTemperature: 1,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   },
 }
 
@@ -241,7 +233,9 @@ export function getModelConfig(alias: string): ModelConfig {
     return MODEL_CONFIGS[lowerAlias]
   }
 
-  // Fallback for unknown models - try to infer from prefix
+  // Fallback for unknown models - try to infer from prefix.
+  // Unknown models get ROOMY_MAX_TOKENS: we cannot tell whether they reason, and a ceiling
+  // that truncates a judge silently corrupts scores, while a loose one only costs tokens.
   if (
     alias.startsWith("gpt-5") ||
     alias.startsWith("o1") ||
@@ -254,8 +248,7 @@ export function getModelConfig(alias: string): ModelConfig {
       displayName: alias,
       supportsTemperature: false,
       defaultTemperature: 1,
-      maxTokensParam: "max_completion_tokens",
-      defaultMaxTokens: 1000,
+      defaultMaxTokens: ROOMY_MAX_TOKENS,
     }
   }
   if (alias.startsWith("gpt-")) {
@@ -265,8 +258,7 @@ export function getModelConfig(alias: string): ModelConfig {
       displayName: alias,
       supportsTemperature: true,
       defaultTemperature: 0,
-      maxTokensParam: "maxTokens",
-      defaultMaxTokens: 1000,
+      defaultMaxTokens: ROOMY_MAX_TOKENS,
     }
   }
   if (alias.startsWith("claude-")) {
@@ -276,8 +268,7 @@ export function getModelConfig(alias: string): ModelConfig {
       displayName: alias,
       supportsTemperature: true,
       defaultTemperature: 0,
-      maxTokensParam: "maxTokens",
-      defaultMaxTokens: 1000,
+      defaultMaxTokens: ROOMY_MAX_TOKENS,
     }
   }
   if (alias.startsWith("gemini-3")) {
@@ -287,8 +278,7 @@ export function getModelConfig(alias: string): ModelConfig {
       displayName: alias,
       supportsTemperature: true,
       defaultTemperature: 1,
-      maxTokensParam: "maxTokens",
-      defaultMaxTokens: 1000,
+      defaultMaxTokens: ROOMY_MAX_TOKENS,
     }
   }
   if (alias.startsWith("gemini-")) {
@@ -298,20 +288,19 @@ export function getModelConfig(alias: string): ModelConfig {
       displayName: alias,
       supportsTemperature: true,
       defaultTemperature: 0,
-      maxTokensParam: "maxTokens",
-      defaultMaxTokens: 1000,
+      defaultMaxTokens: ROOMY_MAX_TOKENS,
     }
   }
 
-  // Default fallback
+  // Default fallback. Also roomy: a future reasoning model (say "o5-mini") matches none of
+  // the prefixes above and lands here, and starving it would silently void its verdicts.
   return {
     id: alias,
     provider: "openai",
     displayName: alias,
     supportsTemperature: true,
     defaultTemperature: 0,
-    maxTokensParam: "maxTokens",
-    defaultMaxTokens: 1000,
+    defaultMaxTokens: ROOMY_MAX_TOKENS,
   }
 }
 


### PR DESCRIPTION
Fixes #62   — `maxTokens` has been a no-op since the AI SDK v5 upgrade, so every judge, answer
and extraction call has been running with no output cap.

## Verified first

    grep -n "maxOutputTokens" node_modules/ai/dist/index.d.ts
    20:    maxOutputTokens?: number;          # v5 CallSettings

`maxTokens` is not a v5 call setting, so the SDK dropped it and `defaultMaxTokens: 1000` never
reached a single request.

## What was hiding it

Every call site built an untyped bag and cast it, which switches off excess-property checking —
precisely the check that would have flagged the rename:

    const params: Record<string, unknown> = { ..., maxTokens: ... }
    await generateText(params as Parameters<typeof generateText>[0])

Each of the five sites is now a plain typed object literal, with the conditional `temperature`
expressed as a spread instead of post-hoc mutation. Reintroducing the old name is now a compile
error, which I confirmed rather than assumed:

    src/judges/anthropic.ts(33,7): error TS2353: Object literal may only specify known
    properties, and 'maxTokens' does not exist in type 'CallSettings & ...'

That's the regression guard — no test needed for it.

## One judgment call beyond the issue text

Making the cap effective is not safe as a pure rename, and shipping it that way would have
traded a cost bug for a correctness bug.

For OpenAI reasoning models the SDK forwards `maxOutputTokens` as `max_completion_tokens`
(`@ai-sdk/openai/dist/index.js:743-748` remaps it), and that budget covers **reasoning tokens
plus visible output**. A newly-enforced 1000 could therefore be consumed entirely by reasoning,
returning empty text — and `parseJudgeResponse` treats unparseable output as `"incorrect"`, so
an `o3` or `gpt-5` judge would have silently scored questions wrong instead of erroring. Gemini
2.5/3 bill thinking against the same ceiling.

So `defaultMaxTokens` is now two tiers: `SHORT_MAX_TOKENS` (1000) for non-reasoning models, and
`ROOMY_MAX_TOKENS` (25000) for reasoning/thinking models and for unrecognised aliases. The
ceiling is a runaway guard, not a budget — short verdicts still use a fraction of it, so the
cost win the issue asks for lands on the models where it's safe.

Two related guards, both cheap, both protecting against truncation that the fix newly makes
possible:

- **Empty judge response now throws** (`judges/base.ts`) instead of scoring `"incorrect"`. The
  evaluate phase records a real, resumable failure rather than quietly biasing accuracy.
- **Extraction cap raised 2000 -> 8000 and truncation is logged** (`prompts/extraction.ts`). A
  truncated extraction silently shrinks the memory corpus that the `filesystem` and `rag`
  providers are scored on, which would read as a provider quality problem rather than a harness
  limit.

If reviewers would rather keep the rename minimal, the tiering and the two guards are separable
hunks — but I'd argue the rename alone is not shippable.

## Also in scope, per the issue

- Deleted the dead `maxTokensParam` field from `ModelConfig`, all 21 registry entries, and the
  five prefix-fallback branches. The SDK already normalizes the per-provider parameter name, so
  there was nothing for it to configure.
- Updated `src/judges/README.md`, which documented that field to anyone adding a judge.

## Tests

`src/utils/models.test.ts` asserts the invariant that matters — reasoning/thinking models and
unknown aliases carry enough headroom to emit a verdict, and known non-reasoning models stay
tightly capped.

It earned its place immediately: it failed on `o5-mini`, a hypothetical future reasoning model
that matches none of the `o1|o3|o4` prefixes and so lands in the final catch-all, which I had
left at 1000. Fixed there too.

`bun test` 4/4 green, `tsc --noEmit` clean, `prettier --check` clean on all touched files.

## Notes for the reviewer

- `src/judges/index.ts` is unformatted at HEAD and I left it alone; every file I touched is
  prettier-clean.
- I ran `bun install --frozen-lockfile` to verify the SDK types against the pinned version;
  `bun.lock` and `package.json` are unmodified.
- `ROOMY_MAX_TOKENS = 25000` is a deliberately conservative ceiling, not a measured figure. If
  you have real reasoning-token numbers from a run, that constant is the one knob to tune.