### PR TITLE
fix(providers): honour the search limit so every provider gets the same result budget

### DIFF
--- a/src/orchestrator/phases/search.ts
+++ b/src/orchestrator/phases/search.ts
@@ -8,6 +8,13 @@ import { logger } from "../../utils/logger"
 import { ConcurrentExecutor } from "../concurrent"
 import { resolveConcurrency } from "../../types/concurrency"
 
+/**
+ * Results requested per question. Every provider gets the same budget, and the same budget
+ * is what retrieval metrics are computed over (`calculateRetrievalMetrics` defaults to k=10).
+ */
+const SEARCH_LIMIT = 10
+const SEARCH_THRESHOLD = 0.3
+
 export async function runSearchPhase(
   provider: Provider,
   benchmark: Benchmark,
@@ -55,11 +62,22 @@ export async function runSearchPhase(
       })
 
       try {
-        const results = await provider.search(question.question, {
+        const returned = await provider.search(question.question, {
           containerTag,
-          limit: 10,
-          threshold: 0.3,
+          limit: SEARCH_LIMIT,
+          threshold: SEARCH_THRESHOLD,
         })
+
+        // Enforce the limit the provider was given. Every result becomes answer-prompt
+        // context, so a provider returning more than its peers gets a free accuracy and
+        // token advantage; truncating here keeps the comparison like-for-like even if a
+        // provider ignores the cap, and the warning stops it happening silently.
+        if (returned.length > SEARCH_LIMIT) {
+          logger.warn(
+            `${provider.name} returned ${returned.length} results for a limit of ${SEARCH_LIMIT}; truncating to keep providers comparable`
+          )
+        }
+        const results = returned.slice(0, SEARCH_LIMIT)
 
         const durationMs = Date.now() - startTime
         const resultFile = join(resultsDir, `${question.questionId}.json`)

--- a/src/orchestrator/search-limit.test.ts
+++ b/src/orchestrator/search-limit.test.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "bun:test"
+import { mkdtempSync, rmSync, readFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { splitSearchBudget } from "../providers/zep"
+import { runSearchPhase } from "./phases/search"
+import { CheckpointManager } from "./checkpoint"
+import type { Provider, SearchOptions } from "../types/provider"
+import type { Benchmark } from "../types/benchmark"
+
+// Every retrieved result becomes context in the answer prompt, so the number of results a
+// provider returns is an accuracy and token advantage. The benchmark's whole cross-provider
+// claim depends on that number being identical for everyone.
+
+test("zep's edge/node budget never exceeds the caller's limit", () => {
+  for (let limit = 1; limit <= 50; limit++) {
+    const { edgeLimit, nodeLimit } = splitSearchBudget(limit)
+    expect(edgeLimit + nodeLimit, `limit=${limit}`).toBeLessThanOrEqual(limit)
+    expect(nodeLimit, `limit=${limit}`).toBeGreaterThanOrEqual(1)
+    expect(edgeLimit, `limit=${limit}`).toBeGreaterThanOrEqual(0)
+  }
+  // Edge-heavy, as before: 10 -> 7 edges + 3 nodes rather than 10 + 10.
+  expect(splitSearchBudget(10)).toEqual({ edgeLimit: 7, nodeLimit: 3 })
+})
+
+function fakeBenchmark(): Benchmark {
+  const question = {
+    questionId: "q1",
+    question: "who?",
+    questionType: "single-session-user",
+    groundTruth: "someone",
+    haystackSessionIds: [],
+  }
+  return {
+    name: "fake",
+    load: async () => {},
+    getQuestions: () => [question],
+    getHaystackSessions: () => [],
+    getGroundTruth: () => question.groundTruth,
+    getQuestionTypes: () => ({}),
+  } as unknown as Benchmark
+}
+
+/** Stands in for a provider that ignores the limit it was handed, as Supermemory did. */
+function greedyProvider(returnCount: number): Provider {
+  return {
+    name: "greedy",
+    initialize: async () => {},
+    ingest: async () => ({ documentIds: [] }),
+    awaitIndexing: async () => {},
+    search: async (_q: string, _o: SearchOptions) =>
+      Array.from({ length: returnCount }, (_, i) => ({ chunk: `result_${i}` })),
+    clear: async () => {},
+  }
+}
+
+test("a provider that over-returns is truncated to the shared limit", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "memorybench-search-"))
+  try {
+    const cm = new CheckpointManager(dir)
+    const checkpoint = cm.create("run-1", "greedy", "fake", "gpt-4o", "gpt-4o")
+    cm.initQuestion(checkpoint, "q1", "q1-run-1", {
+      question: "who?",
+      groundTruth: "someone",
+      questionType: "single-session-user",
+    })
+    // Search only runs for questions whose indexing already completed.
+    checkpoint.questions.q1.phases.indexing.status = "completed"
+
+    await runSearchPhase(greedyProvider(30), fakeBenchmark(), checkpoint, cm, ["q1"])
+    await cm.flush()
+
+    const stored = checkpoint.questions.q1.phases.search.results as unknown[]
+    expect(stored).toHaveLength(10)
+
+    // The persisted result file feeds the answer phase, so it must be capped too.
+    const onDisk = JSON.parse(readFileSync(join(cm.getResultsDir("run-1"), "q1.json"), "utf8"))
+    expect(onDisk.results).toHaveLength(10)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("a compliant provider's results are passed through untouched", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "memorybench-search-"))
+  try {
+    const cm = new CheckpointManager(dir)
+    const checkpoint = cm.create("run-2", "polite", "fake", "gpt-4o", "gpt-4o")
+    cm.initQuestion(checkpoint, "q1", "q1-run-2", {
+      question: "who?",
+      groundTruth: "someone",
+      questionType: "single-session-user",
+    })
+    checkpoint.questions.q1.phases.indexing.status = "completed"
+
+    await runSearchPhase(greedyProvider(4), fakeBenchmark(), checkpoint, cm, ["q1"])
+    await cm.flush()
+
+    expect(checkpoint.questions.q1.phases.search.results as unknown[]).toHaveLength(4)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/src/providers/supermemory/index.ts
+++ b/src/providers/supermemory/index.ts
@@ -123,13 +123,13 @@ export class SupermemoryProvider implements Provider {
     const response = await this.client.search.memories({
       q: query,
       containerTag: options.containerTag,
-      limit: 30,
+      limit: options.limit || 30,
       threshold: options.threshold || 0.3,
-			searchMode: "hybrid",
-			include: {
-				summaries: true,
-				chunks: true
-      }
+      searchMode: "hybrid",
+      include: {
+        summaries: true,
+        chunks: true,
+      },
     })
 
     return response.results || []

--- a/src/providers/zep/index.ts
+++ b/src/providers/zep/index.ts
@@ -13,6 +13,21 @@ import { ZEP_PROMPTS } from "./prompts"
 
 const MAX_DATA_SIZE = 9500
 
+/** Used only when the caller supplies no limit; the search phase always passes one. */
+export const DEFAULT_SEARCH_LIMIT = 20
+
+/**
+ * Zep searches edges and nodes as two separate queries and concatenates the results, so the
+ * caller's limit must be divided between them. Requesting `limit` of each returned up to 2x
+ * the requested count, handing Zep more answer-prompt context than the other providers got.
+ *
+ * Kept edge-heavy (2:1), matching the previous 20-edge / 10-node intent.
+ */
+export function splitSearchBudget(limit: number): { edgeLimit: number; nodeLimit: number } {
+  const nodeLimit = Math.max(1, Math.floor(limit / 3))
+  return { edgeLimit: Math.max(0, limit - nodeLimit), nodeLimit }
+}
+
 function splitIntoChunks(text: string, maxSize: number): string[] {
   if (text.length <= maxSize) return [text]
 
@@ -240,8 +255,7 @@ export class ZepProvider implements Provider {
     }
 
     const finalGraphId = this.graphIds.get(options.containerTag)!
-    const edgeLimit = options.limit || 20
-    const nodeLimit = Math.min(edgeLimit, 10)
+    const { edgeLimit, nodeLimit } = splitSearchBudget(options.limit || DEFAULT_SEARCH_LIMIT)
 
     const [edgesResponse, nodesResponse] = await Promise.all([
       this.client.graph.search({

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -15,6 +15,15 @@ export interface IngestOptions {
 
 export interface SearchOptions {
   containerTag: string
+  /**
+   * Hard cap on the number of results `search` may return, not a hint.
+   *
+   * Every retrieved result is fed to the answering model as context, so a provider that
+   * returns more than it was asked for gets more context than the providers it is being
+   * compared against — an accuracy and token advantage unrelated to retrieval quality.
+   * If a provider searches several scopes, split this budget between them rather than
+   * requesting `limit` of each.
+   */
   limit?: number
   threshold?: number
 }


### PR DESCRIPTION
Fixes #64 — Supermemory hardcoded `limit: 30` while the search phase asked every provider for
10, so it received ~3x the answer-prompt context of the providers it was being compared with.

## Also affected: Zep (the issue's table under-counts it)

While verifying the per-provider table I found a second violation of the same contract. Zep
searches edges and nodes as two separate queries and concatenates them:

    const edgeLimit = options.limit || 20
    const nodeLimit = Math.min(edgeLimit, 10)
    // ...results.push(...edges); results.push(...nodes)

With `limit: 10` that requests 10 of each and returns **up to 20**, not the 10 the issue's
table records. Fixing only Supermemory would have left Zep with roughly double its peers'
context, so the comparison would still not have been like-for-like.

Confirmed compliant: `mem0` (`top_k: options.limit || 30`), `filesystem`, `rag`.

## Changes

**`providers/supermemory`** — `limit: options.limit || 30`, matching how the same call already
treats `options.threshold` one line below. Also normalised the tab-indented `searchMode`/
`include` block, since those are the lines the fix touches and the file was the one file in this
diff that was already failing `prettier --check` at HEAD.

**`providers/zep`** — the limit is now split between the two scopes instead of applied to each,
via an extracted `splitSearchBudget()`. Kept edge-heavy at 2:1 to preserve the previous
20-edge / 10-node intent, so `limit: 10` becomes 7 edges + 3 nodes rather than 10 + 10.

**`orchestrator/phases/search`** — the limit is now enforced at the point results are consumed,
not just requested. A provider that over-returns is truncated to the shared budget and logged:

    WARN greedy returned 30 results for a limit of 10; truncating to keep providers comparable

This is the part that makes the fairness property hold going forward. Patching the two current
offenders fixes today's numbers; the chokepoint means a provider added next month cannot quietly
reintroduce the same advantage. The magic `10` and `0.3` are now named constants, with the
`k = 10` coupling to `calculateRetrievalMetrics` written down.

Note the truncation had to come *with* the Zep fix rather than instead of it: edges are pushed
before nodes, so a blind `slice(0, 10)` on unfixed Zep output would have silently dropped every
node result and turned Zep into an edges-only provider.

**`types/provider`** — documented `limit` as a hard cap rather than a hint, including the
"split the budget across scopes" rule, since `SearchOptions` is where a provider author looks.
The issue suggested surfacing this as a declared capability; documenting the contract and
enforcing it centrally seemed better than adding an interface knob no provider needs yet.

## Tests

`src/orchestrator/search-limit.test.ts`:

- `splitSearchBudget` never exceeds the caller's limit across limits 1..50, always leaves at
  least one node slot, and stays edge-heavy.
- `runSearchPhase` against a stub provider that returns 30 results for a limit of 10: asserts
  both the checkpoint **and** the persisted result file are capped at 10. The file matters
  independently — the answer phase reads context from disk, not from the checkpoint, so a fix
  that capped only one of the two would still have leaked the advantage into the prompt.
- A compliant provider returning 4 results is passed through untouched, so the guard cannot
  quietly become a floor.

`bun test` 3/3, `tsc --noEmit` clean, `prettier --check` clean on all touched files.

## Effect on existing numbers

Any Supermemory or Zep run recorded before this change is not comparable with runs from other
providers, and not comparable with post-fix runs of its own: accuracy, `avgContextTokens`, and
the MemScore token component all move. Published leaderboard entries for those two providers
should be regenerated rather than mixed with new ones.

## Follow-up worth its own issue

Result *count* is now equal, but result *size* is not. Supermemory requests
`include: { summaries: true, chunks: true }`, so one result can carry substantially more text
than one mem0 memory or one Zep edge. `contextTokens` is measured per prompt so it reports this
honestly, but "10 results" still does not mean equal context across providers. Capping by
token budget rather than result count would be the real like-for-like fix, and that is a
design decision rather than a bug fix.