### PR TITLE
fix(metrics): stop reporting Recall@K, F1@K and NDCG that measure nothing

### DIFF
--- a/src/orchestrator/batch.ts
+++ b/src/orchestrator/batch.ts
@@ -1,7 +1,7 @@
 import type { ProviderName } from "../types/provider"
 import type { BenchmarkName } from "../types/benchmark"
 import type { SamplingConfig } from "../types/checkpoint"
-import type { BenchmarkResult } from "../types/unified"
+import type { BenchmarkResult, RetrievalAggregates } from "../types/unified"
 import { orchestrator, CheckpointManager } from "./index"
 import { createBenchmark } from "../benchmarks"
 import { logger } from "../utils/logger"
@@ -432,116 +432,46 @@ export class BatchManager {
     const hasRetrieval = reports.some((r) => r.report.retrieval)
     if (hasRetrieval) {
       const k = reports.find((r) => r.report.retrieval)?.report.retrieval?.k || 10
-      console.log(`\nRETRIEVAL METRICS (K=${k})`)
-      console.log(
-        "┌" +
-          "─".repeat(17) +
-          "┬" +
-          "─".repeat(9) +
-          "┬" +
-          "─".repeat(11) +
-          "┬" +
-          "─".repeat(10) +
-          "┬" +
-          "─".repeat(9) +
-          "┬" +
-          "─".repeat(9) +
-          "┬" +
-          "─".repeat(9) +
-          "┐"
-      )
-      console.log(
-        "│ " +
-          pad("Provider", 15) +
-          " │ " +
-          pad("Hit@K", 7) +
-          " │ " +
-          pad("Precision", 9) +
-          " │ " +
-          pad("Recall", 8) +
-          " │ " +
-          pad("F1", 7) +
-          " │ " +
-          pad("MRR", 7) +
-          " │ " +
-          pad("NDCG", 7) +
-          " │"
-      )
-      console.log(
-        "├" +
-          "─".repeat(17) +
-          "┼" +
-          "─".repeat(9) +
-          "┼" +
-          "─".repeat(11) +
-          "┼" +
-          "─".repeat(10) +
-          "┼" +
-          "─".repeat(9) +
-          "┼" +
-          "─".repeat(9) +
-          "┼" +
-          "─".repeat(9) +
-          "┤"
-      )
+      console.log(`
+RETRIEVAL METRICS (K=${k})`)
+
+      // Recall/F1/NDCG used to sit in this table but were degenerate without ground-truth
+      // relevance counts (see #67), so the columns are derived from one list rather than
+      // repeated across four border strings and two row branches.
+      const columns: Array<{
+        header: string
+        width: number
+        value: (r: RetrievalAggregates) => string
+      }> = [
+        { header: "Provider", width: 15, value: () => "" },
+        { header: "Hit@K", width: 7, value: (r) => padPct(r.hitAtK, 7) },
+        { header: "Precision", width: 9, value: (r) => padPct(r.precisionAtK, 9) },
+        { header: "MRR", width: 7, value: (r) => r.mrr.toFixed(3).padStart(7) },
+      ]
+
+      const border = (left: string, mid: string, right: string) =>
+        left + columns.map((c) => "─".repeat(c.width + 2)).join(mid) + right
+      const row = (cells: string[]) => "│ " + cells.join(" │ ") + " │"
+
+      console.log(border("┌", "┬", "┐"))
+      console.log(row(columns.map((c) => pad(c.header, c.width))))
+      console.log(border("├", "┼", "┤"))
 
       for (const { provider, report } of reports) {
-        if (report.retrieval) {
-          const r = report.retrieval
-          console.log(
-            "│ " +
-              pad(provider, 15) +
-              " │ " +
-              padPct(r.hitAtK, 7) +
-              " │ " +
-              padPct(r.precisionAtK, 9) +
-              " │ " +
-              padPct(r.recallAtK, 8) +
-              " │ " +
-              padPct(r.f1AtK, 7) +
-              " │ " +
-              r.mrr.toFixed(3).padStart(7) +
-              " │ " +
-              r.ndcg.toFixed(3).padStart(7) +
-              " │"
+        const retrieval = report.retrieval
+        console.log(
+          row(
+            columns.map((c, i) =>
+              i === 0
+                ? pad(provider, c.width)
+                : retrieval
+                  ? c.value(retrieval)
+                  : pad("N/A", c.width)
+            )
           )
-        } else {
-          console.log(
-            "│ " +
-              pad(provider, 15) +
-              " │ " +
-              pad("N/A", 7) +
-              " │ " +
-              pad("N/A", 9) +
-              " │ " +
-              pad("N/A", 8) +
-              " │ " +
-              pad("N/A", 7) +
-              " │ " +
-              pad("N/A", 7) +
-              " │ " +
-              pad("N/A", 7) +
-              " │"
-          )
-        }
+        )
       }
-      console.log(
-        "└" +
-          "─".repeat(17) +
-          "┴" +
-          "─".repeat(9) +
-          "┴" +
-          "─".repeat(11) +
-          "┴" +
-          "─".repeat(10) +
-          "┴" +
-          "─".repeat(9) +
-          "┴" +
-          "─".repeat(9) +
-          "┴" +
-          "─".repeat(9) +
-          "┘"
-      )
+      console.log(border("└", "┴", "┘"))
     }
 
     const allTypes = new Set<string>()

--- a/src/orchestrator/phases/report.ts
+++ b/src/orchestrator/phases/report.ts
@@ -22,23 +22,17 @@ function aggregateRetrievalMetrics(metrics: RetrievalMetrics[]): RetrievalAggreg
     (acc, m) => ({
       hitAtK: acc.hitAtK + m.hitAtK,
       precisionAtK: acc.precisionAtK + m.precisionAtK,
-      recallAtK: acc.recallAtK + m.recallAtK,
-      f1AtK: acc.f1AtK + m.f1AtK,
       mrr: acc.mrr + m.mrr,
-      ndcg: acc.ndcg + m.ndcg,
       k: m.k,
     }),
-    { hitAtK: 0, precisionAtK: 0, recallAtK: 0, f1AtK: 0, mrr: 0, ndcg: 0, k: 10 }
+    { hitAtK: 0, precisionAtK: 0, mrr: 0, k: 10 }
   )
 
   const n = metrics.length
   return {
     hitAtK: sum.hitAtK / n,
     precisionAtK: sum.precisionAtK / n,
-    recallAtK: sum.recallAtK / n,
-    f1AtK: sum.f1AtK / n,
     mrr: sum.mrr / n,
-    ndcg: sum.ndcg / n,
     k: sum.k,
   }
 }
@@ -341,10 +335,7 @@ export function printReport(result: BenchmarkResult): void {
     console.log("\nRETRIEVAL QUALITY (K=" + result.retrieval.k + "):")
     console.log(`  Hit@K:      ${(result.retrieval.hitAtK * 100).toFixed(1)}%`)
     console.log(`  Precision:  ${(result.retrieval.precisionAtK * 100).toFixed(1)}%`)
-    console.log(`  Recall:     ${(result.retrieval.recallAtK * 100).toFixed(1)}%`)
-    console.log(`  F1:         ${(result.retrieval.f1AtK * 100).toFixed(1)}%`)
     console.log(`  MRR:        ${result.retrieval.mrr.toFixed(3)}`)
-    console.log(`  NDCG:       ${result.retrieval.ndcg.toFixed(3)}`)
   }
 
   console.log("-".repeat(60))
@@ -361,7 +352,7 @@ export function printReport(result: BenchmarkResult): void {
     )
     if (stats.retrieval) {
       console.log(
-        `    Retrieval: Hit@${stats.retrieval.k}=${(stats.retrieval.hitAtK * 100).toFixed(0)}%, P=${(stats.retrieval.precisionAtK * 100).toFixed(0)}%, R=${(stats.retrieval.recallAtK * 100).toFixed(0)}%, MRR=${stats.retrieval.mrr.toFixed(2)}`
+        `    Retrieval: Hit@${stats.retrieval.k}=${(stats.retrieval.hitAtK * 100).toFixed(0)}%, P=${(stats.retrieval.precisionAtK * 100).toFixed(0)}%, MRR=${stats.retrieval.mrr.toFixed(2)}`
       )
     }
   }

--- a/src/orchestrator/phases/retrieval-eval.test.ts
+++ b/src/orchestrator/phases/retrieval-eval.test.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "bun:test"
+import type { LanguageModel } from "ai"
+import { calculateRetrievalMetrics } from "./retrieval-eval"
+
+// A minimal LanguageModelV2 stub. `ai/test`'s MockLanguageModelV2 would do this for us but it
+// pulls in msw, which isn't a dependency of this project — and a hand-rolled stub is 10 lines.
+function stubJudge(respond: () => string): LanguageModel {
+  return {
+    specificationVersion: "v2",
+    provider: "stub",
+    modelId: "stub-judge",
+    supportedUrls: {},
+    doGenerate: async () => ({
+      content: [{ type: "text" as const, text: respond() }],
+      finishReason: "stop" as const,
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    }),
+    doStream: async () => {
+      throw new Error("not used")
+    },
+  } as unknown as LanguageModel
+}
+
+const judgeReturning = (text: string) => stubJudge(() => text)
+const judgeThatFails = () =>
+  stubJudge(() => {
+    throw new Error("429 rate limited")
+  })
+
+const RESULTS = [{ chunk: "a" }, { chunk: "b" }, { chunk: "c" }, { chunk: "d" }]
+
+test("reports only metrics that are well defined without ground-truth relevance counts", async () => {
+  // 2nd and 4th results relevant.
+  const judge = judgeReturning(
+    JSON.stringify([
+      { id: "result_1", relevant: 0 },
+      { id: "result_2", relevant: 1 },
+      { id: "result_3", relevant: 0 },
+      { id: "result_4", relevant: 1 },
+    ])
+  )
+
+  const metrics = await calculateRetrievalMetrics(judge, "q", "gt", RESULTS)
+
+  expect(metrics).toEqual({
+    hitAtK: 1,
+    precisionAtK: 0.5,
+    mrr: 0.5, // first relevant at rank 2
+    k: 4,
+    relevantRetrieved: 2,
+  })
+  // The degenerate trio must not come back: recall was identical to hitAtK by construction,
+  // F1 was a re-encoding of precision, and NDCG's ideal set was built from what was found.
+  for (const gone of ["recallAtK", "f1AtK", "ndcg", "totalRelevant"]) {
+    expect(metrics).not.toHaveProperty(gone)
+  }
+})
+
+test("precision and MRR distinguish rankings that the old NDCG scored identically", async () => {
+  // Old behaviour: IDCG was built from the retrieved relevant count, so "one relevant at rank 1"
+  // and "four relevant at ranks 1-4" both scored NDCG 1.0 and recall 100%.
+  const onlyFirst = await calculateRetrievalMetrics(
+    judgeReturning(
+      JSON.stringify([
+        { id: "result_1", relevant: 1 },
+        { id: "result_2", relevant: 0 },
+        { id: "result_3", relevant: 0 },
+        { id: "result_4", relevant: 0 },
+      ])
+    ),
+    "q",
+    "gt",
+    RESULTS
+  )
+  const allFour = await calculateRetrievalMetrics(
+    judgeReturning(
+      JSON.stringify([
+        { id: "result_1", relevant: 1 },
+        { id: "result_2", relevant: 1 },
+        { id: "result_3", relevant: 1 },
+        { id: "result_4", relevant: 1 },
+      ])
+    ),
+    "q",
+    "gt",
+    RESULTS
+  )
+
+  // Both "hit" and both rank a relevant result first, so those two agree...
+  expect(onlyFirst!.hitAtK).toBe(allFour!.hitAtK)
+  expect(onlyFirst!.mrr).toBe(allFour!.mrr)
+  // ...but precision now separates them, which is the only honest signal available here.
+  expect(onlyFirst!.precisionAtK).toBe(0.25)
+  expect(allFour!.precisionAtK).toBe(1)
+})
+
+test("a judge failure yields no metrics instead of a zero score", async () => {
+  // Coercing a rate-limit or timeout to relevant:0 was indistinguishable from "retrieved
+  // nothing useful" and quietly dragged the provider's retrieval numbers down.
+  const metrics = await calculateRetrievalMetrics(judgeThatFails(), "q", "gt", RESULTS)
+
+  expect(metrics).toBeUndefined()
+})
+
+test("an unparseable judge response yields no metrics", async () => {
+  const metrics = await calculateRetrievalMetrics(
+    judgeReturning("I'm afraid I can't help with that."),
+    "q",
+    "gt",
+    RESULTS
+  )
+
+  expect(metrics).toBeUndefined()
+})
+
+test("retrieving nothing is a real zero, not a missing measurement", async () => {
+  const metrics = await calculateRetrievalMetrics(judgeReturning("[]"), "q", "gt", [])
+
+  expect(metrics).toEqual({ hitAtK: 0, precisionAtK: 0, mrr: 0, k: 0, relevantRetrieved: 0 })
+})

--- a/src/orchestrator/phases/retrieval-eval.ts
+++ b/src/orchestrator/phases/retrieval-eval.ts
@@ -1,6 +1,7 @@
 import type { RetrievalMetrics } from "../../types/unified"
 import type { LanguageModel } from "ai"
 import { generateText } from "ai"
+import { logger } from "../../utils/logger"
 
 interface RelevanceResult {
   id: string
@@ -12,7 +13,7 @@ async function evaluateAllChunks(
   question: string,
   groundTruth: string,
   searchResults: unknown[]
-): Promise<RelevanceResult[]> {
+): Promise<RelevanceResult[] | null> {
   if (searchResults.length === 0) return []
 
   const formattedResults = searchResults
@@ -51,6 +52,10 @@ Where:
 
 Return ONLY the JSON array, no other text.`
 
+  // A judge that times out, rate-limits, or answers unparseably tells us nothing about
+  // relevance. Returning all-zeros made that indistinguishable from "the provider retrieved
+  // nothing useful" and quietly dragged the provider's retrieval numbers down, so failures
+  // now return null and the question is left out of the aggregate instead.
   try {
     const response = await generateText({
       model,
@@ -59,89 +64,57 @@ Return ONLY the JSON array, no other text.`
 
     const jsonMatch = response.text.match(/\[[\s\S]*\]/)
     if (!jsonMatch) {
-      return searchResults.map((_, i) => ({ id: `result_${i + 1}`, relevant: 0 as const }))
+      logger.warn("Relevance judge returned no JSON array; skipping retrieval metrics")
+      return null
     }
 
-    const parsed = JSON.parse(jsonMatch[0]) as RelevanceResult[]
-    return parsed
-  } catch {
-    return searchResults.map((_, i) => ({ id: `result_${i + 1}`, relevant: 0 as const }))
+    return JSON.parse(jsonMatch[0]) as RelevanceResult[]
+  } catch (e) {
+    logger.warn(`Relevance judge failed; skipping retrieval metrics: ${e}`)
+    return null
   }
 }
 
-function calculateNDCG(relevanceScores: number[], idealRelevant: number): number {
-  const dcg = relevanceScores.reduce((sum, rel, i) => {
-    return sum + rel / Math.log2(i + 2)
-  }, 0)
-
-  const idealScores = Array(relevanceScores.length).fill(0)
-  for (let i = 0; i < Math.min(idealRelevant, idealScores.length); i++) {
-    idealScores[i] = 1
-  }
-  const idcg = idealScores.reduce((sum, rel, i) => {
-    return sum + rel / Math.log2(i + 2)
-  }, 0)
-
-  return idcg > 0 ? dcg / idcg : 0
-}
-
+/**
+ * Retrieval metrics for one question, or `undefined` when the relevance judge could not be
+ * consulted — the caller leaves those questions out of the aggregate rather than recording
+ * a zero it cannot justify.
+ *
+ * Only metrics that are well defined without a ground-truth relevance count are produced.
+ * Recall@K, F1@K and NDCG need to know how many relevant memories exist in the corpus; that
+ * number is not available here, and substituting the retrieved count (as this used to) makes
+ * recall identical to Hit@K and NDCG blind to anything the provider missed.
+ */
 export async function calculateRetrievalMetrics(
   model: LanguageModel,
   question: string,
   groundTruth: string,
   searchResults: unknown[],
   k: number = 10
-): Promise<RetrievalMetrics> {
+): Promise<RetrievalMetrics | undefined> {
   const resultsToEval = searchResults.slice(0, k)
 
   if (resultsToEval.length === 0) {
-    return {
-      hitAtK: 0,
-      precisionAtK: 0,
-      recallAtK: 0,
-      f1AtK: 0,
-      mrr: 0,
-      ndcg: 0,
-      k: 0,
-      relevantRetrieved: 0,
-      totalRelevant: 1,
-    }
+    // Retrieved nothing, so nothing was relevant. This is a real measurement, not a failure.
+    return { hitAtK: 0, precisionAtK: 0, mrr: 0, k: 0, relevantRetrieved: 0 }
   }
 
   const relevanceResults = await evaluateAllChunks(model, question, groundTruth, resultsToEval)
+  if (relevanceResults === null) return undefined
 
   const relevanceScores = resultsToEval.map((_, i) => {
-    const id = `result_${i + 1}`
-    const result = relevanceResults.find((r) => r.id === id)
+    const result = relevanceResults.find((r) => r.id === `result_${i + 1}`)
     return result?.relevant === 1 ? 1 : 0
   })
 
   const relevantRetrieved = relevanceScores.filter((r) => r === 1).length
-  const totalRelevant = Math.max(1, relevantRetrieved)
-
-  const hitAtK = relevantRetrieved > 0 ? 1 : 0
-
-  const precisionAtK = resultsToEval.length > 0 ? relevantRetrieved / resultsToEval.length : 0
-
-  const recallAtK = relevantRetrieved > 0 ? 1 : 0
-
-  const f1AtK =
-    precisionAtK + recallAtK > 0 ? (2 * (precisionAtK * recallAtK)) / (precisionAtK + recallAtK) : 0
-
   const firstRelevantIndex = relevanceScores.findIndex((r) => r === 1)
-  const mrr = firstRelevantIndex >= 0 ? 1 / (firstRelevantIndex + 1) : 0
-
-  const ndcg = calculateNDCG(relevanceScores, totalRelevant)
 
   return {
-    hitAtK,
-    precisionAtK,
-    recallAtK,
-    f1AtK,
-    mrr,
-    ndcg,
+    hitAtK: relevantRetrieved > 0 ? 1 : 0,
+    precisionAtK: relevantRetrieved / resultsToEval.length,
+    mrr: firstRelevantIndex >= 0 ? 1 / (firstRelevantIndex + 1) : 0,
     k: resultsToEval.length,
     relevantRetrieved,
-    totalRelevant,
   }
 }

--- a/src/types/unified.ts
+++ b/src/types/unified.ts
@@ -30,25 +30,28 @@ export interface UnifiedQuestion {
 
 export type SearchResult = unknown
 
+/**
+ * Retrieval quality over the results a provider returned for one question.
+ *
+ * Deliberately limited to metrics that are well defined without knowing how many relevant
+ * memories exist in the corpus. Recall@K, F1@K and NDCG were previously reported here, but
+ * with no ground-truth denominator they were computed against the retrieved set itself: recall
+ * reduced to exactly hitAtK, F1 to a re-encoding of precision, and NDCG's ideal ranking was
+ * built from what the provider happened to find, so it could never register a miss. See the
+ * issue trail on #67 before adding them back — they need per-question relevance labels first.
+ */
 export interface RetrievalMetrics {
   hitAtK: number
   precisionAtK: number
-  recallAtK: number
-  f1AtK: number
   mrr: number
-  ndcg: number
   k: number
   relevantRetrieved: number
-  totalRelevant: number
 }
 
 export interface RetrievalAggregates {
   hitAtK: number
   precisionAtK: number
-  recallAtK: number
-  f1AtK: number
   mrr: number
-  ndcg: number
   k: number
 }
 

--- a/ui/app/compare/[compareId]/page.tsx
+++ b/ui/app/compare/[compareId]/page.tsx
@@ -21,6 +21,18 @@ import { Tooltip } from "@/components/tooltip"
 
 const POLL_INTERVAL = 2000 // 2 seconds
 
+/**
+ * Retrieval columns, defined once so the header and body cannot drift apart.
+ *
+ * Recall, F1 and NDCG used to appear here. They were degenerate without ground-truth relevance
+ * counts — recall was identical to Hit@K by construction — so they are no longer reported (#67).
+ */
+const RETRIEVAL_COLUMNS = [
+  { key: "hitAtK", label: "Hit@K", format: (v: number) => `${(v * 100).toFixed(0)}%` },
+  { key: "precisionAtK", label: "Precision", format: (v: number) => `${(v * 100).toFixed(0)}%` },
+  { key: "mrr", label: "MRR", format: (v: number) => v.toFixed(2) },
+] as const
+
 export default function CompareDetailPage() {
   const params = useParams()
   const router = useRouter()
@@ -567,27 +579,17 @@ export default function CompareDetailPage() {
                 <table className="w-full text-sm table-fixed">
                   <thead>
                     <tr className="border-b border-border">
-                      <th className="w-[14.28%] text-left py-2 px-3 text-text-muted font-medium uppercase text-xs">
+                      <th className="w-1/4 text-left py-2 px-3 text-text-muted font-medium uppercase text-xs">
                         Provider
                       </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        Hit@K
-                      </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        Precision
-                      </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        Recall
-                      </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        F1
-                      </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        MRR
-                      </th>
-                      <th className="w-[14.28%] text-right py-2 px-3 text-text-muted font-medium uppercase text-xs">
-                        NDCG
-                      </th>
+                      {RETRIEVAL_COLUMNS.map((c) => (
+                        <th
+                          key={c.key}
+                          className="w-1/4 text-right py-2 px-3 text-text-muted font-medium uppercase text-xs"
+                        >
+                          {c.label}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
@@ -602,7 +604,7 @@ export default function CompareDetailPage() {
                       if (rows.length === 0) {
                         return (
                           <tr>
-                            <td colSpan={7} className="py-4 px-3 text-center text-text-secondary">
+                            <td colSpan={4} className="py-4 px-3 text-center text-text-secondary">
                               Retrieval metrics not available
                             </td>
                           </tr>
@@ -610,20 +612,11 @@ export default function CompareDetailPage() {
                       }
 
                       // Find best values and FIRST index for each metric
-                      const metrics = [
-                        "hitAtK",
-                        "precisionAtK",
-                        "recallAtK",
-                        "f1AtK",
-                        "mrr",
-                        "ndcg",
-                      ] as const
-                      const bestByMetric = metrics.reduce(
-                        (acc, metric) => {
-                          const values = rows.map((r) => r.retrieval[metric])
+                      const bestByMetric = RETRIEVAL_COLUMNS.reduce(
+                        (acc, { key }) => {
+                          const values = rows.map((r) => r.retrieval[key])
                           const bestValue = Math.max(...values)
-                          const firstBestIndex = values.findIndex((v) => v === bestValue)
-                          acc[metric] = { value: bestValue, firstIndex: firstBestIndex }
+                          acc[key] = { value: bestValue, firstIndex: values.indexOf(bestValue) }
                           return acc
                         },
                         {} as Record<string, { value: number; firstIndex: number }>
@@ -632,72 +625,19 @@ export default function CompareDetailPage() {
                       return rows.map((row, rowIndex) => (
                         <tr key={row.provider} className="border-b border-border/50">
                           <td className="py-2 px-3 text-text-primary capitalize">{row.provider}</td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.hitAtK.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {(row.retrieval.hitAtK * 100).toFixed(0)}%
-                            </span>
-                          </td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.precisionAtK.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {(row.retrieval.precisionAtK * 100).toFixed(0)}%
-                            </span>
-                          </td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.recallAtK.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {(row.retrieval.recallAtK * 100).toFixed(0)}%
-                            </span>
-                          </td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.f1AtK.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {(row.retrieval.f1AtK * 100).toFixed(0)}%
-                            </span>
-                          </td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.mrr.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {row.retrieval.mrr.toFixed(2)}
-                            </span>
-                          </td>
-                          <td className="py-2 px-3 text-right font-mono">
-                            <span
-                              className={
-                                rowIndex === bestByMetric.ndcg.firstIndex
-                                  ? "text-white font-semibold"
-                                  : "text-text-secondary"
-                              }
-                            >
-                              {row.retrieval.ndcg.toFixed(2)}
-                            </span>
-                          </td>
+                          {RETRIEVAL_COLUMNS.map(({ key, format }) => (
+                            <td key={key} className="py-2 px-3 text-right font-mono">
+                              <span
+                                className={
+                                  rowIndex === bestByMetric[key].firstIndex
+                                    ? "text-white font-semibold"
+                                    : "text-text-secondary"
+                                }
+                              >
+                                {format(row.retrieval[key])}
+                              </span>
+                            </td>
+                          ))}
                         </tr>
                       ))
                     })()}

--- a/ui/components/benchmark-results.tsx
+++ b/ui/components/benchmark-results.tsx
@@ -111,10 +111,7 @@ export interface LatencyStats {
 export interface RetrievalStats {
   hitAtK: number
   precisionAtK: number
-  recallAtK: number
-  f1AtK: number
   mrr: number
-  ndcg: number
   k: number
 }
 
@@ -217,7 +214,7 @@ export function RetrievalMetrics({ retrieval, byQuestionType }: RetrievalMetrics
         Retrieval Quality (K={retrieval.k})
       </h3>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div className="bg-bg-primary p-3 rounded border border-border">
           <div className="text-xs text-text-muted uppercase tracking-wide mb-1">
             Hit@{retrieval.k}
@@ -228,23 +225,18 @@ export function RetrievalMetrics({ retrieval, byQuestionType }: RetrievalMetrics
           <div className="text-xs text-text-secondary">found relevant</div>
         </div>
         <div className="bg-bg-primary p-3 rounded border border-border">
+          <div className="text-xs text-text-muted uppercase tracking-wide mb-1">
+            Precision@{retrieval.k}
+          </div>
+          <div className="text-xl font-mono text-text-primary">
+            {(retrieval.precisionAtK * 100).toFixed(0)}%
+          </div>
+          <div className="text-xs text-text-secondary">relevant out of retrieved</div>
+        </div>
+        <div className="bg-bg-primary p-3 rounded border border-border">
           <div className="text-xs text-text-muted uppercase tracking-wide mb-1">MRR</div>
           <div className="text-xl font-mono text-text-primary">{retrieval.mrr.toFixed(2)}</div>
           <div className="text-xs text-text-secondary">mean reciprocal rank</div>
-        </div>
-        <div className="bg-bg-primary p-3 rounded border border-border">
-          <div className="text-xs text-text-muted uppercase tracking-wide mb-1">NDCG</div>
-          <div className="text-xl font-mono text-text-primary">{retrieval.ndcg.toFixed(2)}</div>
-          <div className="text-xs text-text-secondary">ranking quality</div>
-        </div>
-        <div className="bg-bg-primary p-3 rounded border border-border">
-          <div className="text-xs text-text-muted uppercase tracking-wide mb-1">
-            F1@{retrieval.k}
-          </div>
-          <div className="text-xl font-mono text-text-primary">
-            {(retrieval.f1AtK * 100).toFixed(0)}%
-          </div>
-          <div className="text-xs text-text-secondary">precision-recall balance</div>
         </div>
       </div>
 
@@ -269,47 +261,37 @@ export function RetrievalMetrics({ retrieval, byQuestionType }: RetrievalMetrics
             </tr>
           </thead>
           <tbody>
-            {(["hitAtK", "precisionAtK", "recallAtK", "f1AtK", "mrr", "ndcg"] as const).map(
-              (metric) => {
-                const labels: Record<string, string> = {
-                  hitAtK: `Hit@${retrieval.k}`,
-                  precisionAtK: "Precision",
-                  recallAtK: "Recall",
-                  f1AtK: "F1",
-                  mrr: "MRR",
-                  ndcg: "NDCG",
-                }
-                const tooltips: Record<string, string> = {
-                  hitAtK: "found at least one relevant result",
-                  precisionAtK: "relevant results out of retrieved",
-                  recallAtK: "found relevant content",
-                  f1AtK: "precision-recall balance",
-                  mrr: "mean reciprocal rank",
-                  ndcg: "ranking quality score",
-                }
-                const isPercentage = ["hitAtK", "precisionAtK", "recallAtK", "f1AtK"].includes(
-                  metric
-                )
-                const format = (v: number) =>
-                  isPercentage ? `${(v * 100).toFixed(1)}%` : v.toFixed(3)
-
-                return (
-                  <tr key={metric} className="border-b border-border/50">
-                    <td className="py-2 px-3 text-text-primary">
-                      <Tooltip text={tooltips[metric]}>{labels[metric]}</Tooltip>
-                    </td>
-                    <td className="py-2 px-3 text-right font-mono text-text-primary">
-                      {format(retrieval[metric])}
-                    </td>
-                    {questionTypes.map(([type, stats]) => (
-                      <td key={type} className="py-2 px-3 text-right font-mono text-text-secondary">
-                        {stats.retrieval ? format(stats.retrieval[metric]) : "—"}
-                      </td>
-                    ))}
-                  </tr>
-                )
+            {(["hitAtK", "precisionAtK", "mrr"] as const).map((metric) => {
+              const labels: Record<string, string> = {
+                hitAtK: `Hit@${retrieval.k}`,
+                precisionAtK: "Precision",
+                mrr: "MRR",
               }
-            )}
+              const tooltips: Record<string, string> = {
+                hitAtK: "found at least one relevant result",
+                precisionAtK: "relevant results out of retrieved",
+                mrr: "mean reciprocal rank",
+              }
+              const isPercentage = ["hitAtK", "precisionAtK"].includes(metric)
+              const format = (v: number) =>
+                isPercentage ? `${(v * 100).toFixed(1)}%` : v.toFixed(3)
+
+              return (
+                <tr key={metric} className="border-b border-border/50">
+                  <td className="py-2 px-3 text-text-primary">
+                    <Tooltip text={tooltips[metric]}>{labels[metric]}</Tooltip>
+                  </td>
+                  <td className="py-2 px-3 text-right font-mono text-text-primary">
+                    {format(retrieval[metric])}
+                  </td>
+                  {questionTypes.map(([type, stats]) => (
+                    <td key={type} className="py-2 px-3 text-right font-mono text-text-secondary">
+                      {stats.retrieval ? format(stats.retrieval[metric]) : "—"}
+                    </td>
+                  ))}
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -402,10 +402,7 @@ export interface BenchmarkResult {
   retrieval?: {
     hitAtK: number
     precisionAtK: number
-    recallAtK: number
-    f1AtK: number
     mrr: number
-    ndcg: number
     k: number
   }
   evaluations?: EvaluationResult[]


### PR DESCRIPTION
Fixes #67 — four of the six numbers under "RETRIEVAL QUALITY" were either duplicates or
non-standard quantities published under standard names.

## Which option I took, and why

The issue offers two routes. I took the second one — stop emitting the degenerate metrics —
rather than wiring up LongMemEval's `has_answer`.

`has_answer` marks haystack **messages**, but retrieval metrics are computed over what a
provider *returns*: Supermemory memories, Mem0 memories, Zep graph edges and nodes, RAG chunks.
There is no uniform mapping from those artifacts back to source messages, so `has_answer` cannot
produce a trustworthy `totalRelevant` for the thing actually being scored — and LoCoMo and
ConvoMem don't ship equivalent labels at all, so it would only ever have worked for one
benchmark. Real relevance labels are a design change, not a bug fix; a wrong recall denominator
would be worse than none.

So this PR makes the reports honest now, and leaves the door open.

## Changes

**Dropped `recallAtK`, `f1AtK`, `ndcg` and `totalRelevant`** from `RetrievalMetrics` /
`RetrievalAggregates`, the CLI report, the compare table, and the UI. Kept `hitAtK`,
`precisionAtK`, `mrr`, `k` and `relevantRetrieved` — all well defined without knowing the corpus.
`calculateNDCG` is deleted as dead code, and the reason is recorded on the type so the trio
doesn't get reintroduced by someone reading the field list and noticing gaps.

**Judge failures no longer score as "not relevant".** Both error paths in `evaluateAllChunks`
returned all-zero relevance, making a rate-limit or a timeout indistinguishable from "the
provider retrieved nothing useful" — quietly penalising the provider for the judge's problem.
They now return `null`, `calculateRetrievalMetrics` returns `undefined`, and the question is
excluded from the aggregate instead of contributing a zero. Both paths log a warning.

Note the distinction that had to be preserved: **retrieving nothing is still a real zero**
(`hitAtK: 0`, `k: 0`), because that's a measurement. Only judge *failure* is absent. Collapsing
those two would have swapped one silent bias for another.

**Collapsed two duplicated tables.** Removing three of seven columns from the compare table
meant editing the same width list in four border strings plus two row branches
(`batch.ts`), and three near-identical 12-line `<td>` blocks plus a 7-cell header
(`compare/[compareId]/page.tsx`). Both are now driven by a single column list, so header and body
cannot drift. That's where most of the −184 lines come from; it wasn't the goal but it was the
cheaper way to make the change correctly.

## Tests

`src/orchestrator/phases/retrieval-eval.test.ts` drives the real code path against a stub
language model:

- The reduced metric set is computed correctly, and asserts the four removed fields are *absent*
  from the output.
- **The bug, made concrete:** "one relevant result at rank 1" and "four relevant results at ranks
  1–4" used to both score NDCG 1.0 and Recall 100%. The test shows Hit@K and MRR agree on those
  two cases (correctly — both hit, both rank a relevant result first) while Precision now
  separates them 25% vs 100%, which is the only honest signal available without labels.
- A judge that throws, and a judge that answers unparseably, both yield no metrics rather than a
  zero.
- An empty result set still yields a real zero.

The stub is hand-rolled (~10 lines) rather than `ai/test`'s `MockLanguageModelV2`, which pulls in
`msw` — not a dependency here, and not worth adding for one test.

`bun test` 5/5, `tsc --noEmit` clean on `src`.

## Compatibility

Report JSON and leaderboard rows written before this change still carry the removed fields; they
are simply ignored, so old reports render fine. New reports omit them, and the UI no longer reads
them, so there is no undefined-access path in either direction. No migration needed.

Anyone quoting Recall@K / F1@K / NDCG from a MemoryBench report should treat those figures as
withdrawn rather than changed — they were never measuring what their names implied.

## Notes for the reviewer

- `src/orchestrator/phases/report.ts` was already failing `prettier --check` at HEAD on a
  pre-existing `basePromptTokens` line. I left that line alone rather than bundle a reformat with
  a metrics change; every line I added is prettier-clean, and the other six files are fully clean.
- `ui/` has 4 pre-existing type errors (`LeaderboardEntry.retrieval`, `promptTokens` in
  `question-list.tsx`). I verified the error set is **identical** before and after this change, so
  none are mine — but they mean `ui` does not currently typecheck, worth its own fix.
- **Still broken, deliberately left alone:** `aggregateRetrievalMetrics` sets `k: m.k` inside the
  reduce, so the aggregate `k` is whichever question came last rather than the run's `k` — reports
  can still print `RETRIEVAL QUALITY (K=0)`. It's in a function this PR rewrites, but it's a
  separate defect with its own issue, and folding it in would blur what this change is
  accountable for.