### PR TITLE
fix(rag): make BM25 indexing incremental and idempotent

### DIFF
--- a/src/providers/rag/search.test.ts
+++ b/src/providers/rag/search.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { HybridSearchEngine, type Chunk } from "./search"
+
+const CONTAINER = "test_container"
+
+function makeChunk(id: string, content: string, embedding: number[]): Chunk {
+  return {
+    id,
+    content,
+    sessionId: id,
+    chunkIndex: 0,
+    embedding,
+  }
+}
+
+// Deliberately uneven document lengths and term frequencies: avgDocLength and
+// idf both have to be wrong for these scores to move.
+const CHUNKS: Chunk[] = [
+  makeChunk("c1", "quantum telescope", [1, 0, 0]),
+  makeChunk(
+    "c2",
+    "harvest orbital drift sensor array calibration payload module thermal shielding harvest harvest",
+    [0, 1, 0]
+  ),
+  makeChunk("c3", "harvest sensor", [0, 0, 1]),
+]
+
+const QUERY = "quantum harvest"
+const QUERY_EMBEDDING = [0.5, 0.5, 0.5]
+
+describe("HybridSearchEngine BM25 indexing", () => {
+  test("re-ingesting the same chunks does not change search scores", () => {
+    const fresh = new HybridSearchEngine()
+    fresh.addChunks(CONTAINER, CHUNKS)
+
+    const reingested = new HybridSearchEngine()
+    reingested.addChunks(CONTAINER, CHUNKS)
+    reingested.addChunks(CONTAINER, CHUNKS)
+
+    expect(reingested.getChunkCount(CONTAINER)).toBe(CHUNKS.length)
+    expect(reingested.search(CONTAINER, QUERY_EMBEDDING, QUERY, 10)).toEqual(
+      fresh.search(CONTAINER, QUERY_EMBEDDING, QUERY, 10)
+    )
+  })
+
+  test("re-indexing a chunk with new content drops its old terms", () => {
+    const engine = new HybridSearchEngine()
+    engine.addChunks(CONTAINER, [
+      makeChunk("c1", "telescope calibration", [1, 0, 0]),
+      makeChunk("c2", "telescope beacon", [0, 1, 0]),
+    ])
+
+    // Same chunk ID, different content — as produced by a forced re-ingest.
+    engine.addChunks(CONTAINER, [makeChunk("c1", "harvest orbital", [1, 0, 0])])
+
+    const results = engine.search(CONTAINER, [1, 1, 0], "telescope", 10)
+    const c1 = results.find((r) => r.content === "harvest orbital")
+    const c2 = results.find((r) => r.content === "telescope beacon")
+
+    expect(c1).toBeDefined()
+    expect(c2).toBeDefined()
+    expect(c1!.bm25Score).toBe(0)
+    expect(c2!.bm25Score).toBeGreaterThan(0)
+  })
+
+  test("scores match a freshly built index after content is replaced", () => {
+    const replaced = new HybridSearchEngine()
+    replaced.addChunks(CONTAINER, [makeChunk("c1", "telescope calibration payload", [1, 0, 0])])
+    replaced.addChunks(CONTAINER, CHUNKS)
+
+    const fresh = new HybridSearchEngine()
+    fresh.addChunks(CONTAINER, CHUNKS)
+
+    expect(replaced.search(CONTAINER, QUERY_EMBEDDING, QUERY, 10)).toEqual(
+      fresh.search(CONTAINER, QUERY_EMBEDDING, QUERY, 10)
+    )
+  })
+})

--- a/src/providers/rag/search.ts
+++ b/src/providers/rag/search.ts
@@ -165,6 +165,10 @@ interface BM25Index {
   invertedIndex: Map<string, Map<string, number>>
   /** Document lengths (in tokens) */
   docLengths: Map<string, number>
+  /** Distinct terms per document, so re-indexing can drop stale postings */
+  docTerms: Map<string, Set<string>>
+  /** Running sum of all document lengths */
+  totalLength: number
   /** Average document length */
   avgDocLength: number
   /** Total number of documents */
@@ -175,22 +179,44 @@ function createBM25Index(): BM25Index {
   return {
     invertedIndex: new Map(),
     docLengths: new Map(),
+    docTerms: new Map(),
+    totalLength: 0,
     avgDocLength: 0,
     docCount: 0,
   }
 }
 
+function removeFromBM25Index(index: BM25Index, chunkId: string): void {
+  const docLength = index.docLengths.get(chunkId)
+  if (docLength === undefined) return
+
+  for (const term of index.docTerms.get(chunkId) || []) {
+    const postings = index.invertedIndex.get(term)
+    if (!postings) continue
+    postings.delete(chunkId)
+    if (postings.size === 0) index.invertedIndex.delete(term)
+  }
+
+  index.docTerms.delete(chunkId)
+  index.docLengths.delete(chunkId)
+  index.docCount--
+  index.totalLength -= docLength
+  index.avgDocLength = index.docCount > 0 ? index.totalLength / index.docCount : 0
+}
+
 function addToBM25Index(index: BM25Index, chunkId: string, text: string): void {
+  // Chunk IDs are deterministic, so a forced or resumed ingest re-adds the same
+  // ID. Replace the existing entry instead of appending to it, otherwise
+  // docCount drifts above docLengths.size and skews both idf and avgDocLength.
+  removeFromBM25Index(index, chunkId)
+
   const tokens = tokenize(text)
   index.docLengths.set(chunkId, tokens.length)
   index.docCount++
 
-  // Update average document length
-  let totalLength = 0
-  for (const len of index.docLengths.values()) {
-    totalLength += len
-  }
-  index.avgDocLength = totalLength / index.docCount
+  // Update average document length from a running total, not a full rescan
+  index.totalLength += tokens.length
+  index.avgDocLength = index.totalLength / index.docCount
 
   // Build term frequency map
   const termFreqs = new Map<string, number>()
@@ -205,6 +231,7 @@ function addToBM25Index(index: BM25Index, chunkId: string, text: string): void {
     }
     index.invertedIndex.get(term)!.set(chunkId, freq)
   }
+  index.docTerms.set(chunkId, new Set(termFreqs.keys()))
 }
 
 function searchBM25(index: BM25Index, query: string): Map<string, number> {


### PR DESCRIPTION
Fixes #74.

## Problem

Two defects in `addToBM25Index` (`src/providers/rag/search.ts`).

**1. Quadratic ingest.** `avgDocLength` was recomputed by walking the entire `docLengths` map on every single insert, so indexing *n* chunks scanned the map *n* times.

**2. Re-ingest corrupted the index.** `addChunks` overwrites `container.chunks` (idempotent) but `addToBM25Index` unconditionally did `docCount++`. Chunk IDs are deterministic (`${containerTag}_${sessionId}_${chunkIndex}`), so a forced or resumed ingest re-adds the same IDs — `docCount` drifted above `docLengths.size`, which skewed:

- `avgDocLength = totalLength / docCount` → understated, distorting length normalisation for *every* document
- `idf = log((docCount - df + 0.5) / (df + 0.5) + 1)` → inflated for every term

Postings from the replaced content were also left behind, so a chunk kept matching terms that were no longer in its text. Since BM25 carries 30% of the hybrid score, `rag` retrieval quality depended on run history rather than on the algorithm.

## Fix

- Track a running `totalLength` on the index instead of rescanning.
- Track `docTerms` (distinct terms per document) so `removeFromBM25Index` can drop an entry's postings, length and count in O(terms) before it is re-added.
- `addToBM25Index` now replaces rather than appends, keeping `docCount === docLengths.size` and the inverted index consistent with current content.

No public API change; `HybridSearchEngine` behaves identically for a fresh ingest.

## Tests

New `src/providers/rag/search.test.ts` (3 tests, run with `bun test`):

- re-ingesting the same chunks yields byte-identical search results to a fresh index
- re-indexing a chunk with new content drops its old terms (stale posting scores 0)
- an index whose content was replaced matches a freshly built one

All three fail on `main` and pass with this change.

## Ingest timing

`addChunks` with 30-token chunks, before → after:

| chunks | before | after |
|---|---|---|
| 5,000 | 219 ms | 157 ms |
| 10,000 | 478 ms | 264 ms |
| 20,000 | 1,426 ms | 456 ms |
| 40,000 | 6,140 ms | 1,481 ms |

Before scales ~4x per doubling; after, ~2x.

`bunx tsc --noEmit` is clean and the new file is Prettier-clean. I left the pre-existing Prettier warnings elsewhere in `search.ts` alone to keep the diff scoped — `bun run format:check` already fails on 69 files on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqGuPVWVYRJEJQp2RXchf1
