### PR TITLE
fix(locomo): correct category mapping to match official dataset

### DIFF
--- a/src/benchmarks/locomo/index.ts
+++ b/src/benchmarks/locomo/index.ts
@@ -67,10 +67,10 @@ export const LOCOMO_QUESTION_TYPES: QuestionTypeRegistry = {
 }
 
 const CATEGORY_TO_TYPE: Record<number, string> = {
-  1: "single-hop",
-  2: "multi-hop",
-  3: "temporal",
-  4: "world-knowledge",
+  1: "multi-hop",
+  2: "temporal",
+  3: "world-knowledge",
+  4: "single-hop",
   5: "adversarial",
 }
 


### PR DESCRIPTION
## Description
Fixes a bug in the \CATEGORY_TO_TYPE\ mapping for the LoCoMo benchmark.

What was wrong?
The MemoryBench codebase incorrectly mapped the LoCoMo categories as follows:

1: single-hop (Incorrect)
2: multi-hop (Incorrect)
3: temporal (Incorrect)

Because of this bug, any results generated by MemoryBench for LoCoMo were scrambling the metric breakdown. A model's "Temporal" score was actually being reported as its "World Knowledge" score, and its "Single-hop" score was being mixed up with "Multi-hop".

The official LoCoMo dataset uses the following mapping:
- \1\: multi-hop
- \2\: temporal
- \3\: world-knowledge
- \4\: single-hop
- \5\: adversarial

**Proof:**
In the official [snap-research/locomo evaluation code](https://github.com/snap-research/locomo/blob/main/task_eval/gpt_utils.py#L210), they explicitly force the LLM to use the conversation date for Category 2:
\if qa['category'] == 2: questions.append(qa['question'] + ' Use DATE of CONVERSATION to answer with an approximate date.')\

Additionally, their [evaluation script](https://github.com/snap-research/locomo/blob/main/task_eval/evaluation_stats.py#L182) prints the results using the array \keys = [4, 1, 2, 3, 5]\, which aligns with the paper's results ordering (Single-hop, Multi-hop, Temporal, World-knowledge, Adversarial).

This PR fixes the upstream mapping to match this so that leaderboard metrics are correctly labeled.